### PR TITLE
APM-4116: Remove auth component of path used when calling keycloak

### DIFF
--- a/proxygen_cli/lib/credentials.py
+++ b/proxygen_cli/lib/credentials.py
@@ -23,7 +23,7 @@ def _yaml_credentials_file_source(_):
 
 class Credentials(BaseSettings):
     base_url: AnyHttpUrl = (
-        "https://identity.prod.api.platform.nhs.uk/auth/realms/api-producers"
+        "https://identity.prod.api.platform.nhs.uk/realms/api-producers"
     )
     private_key_path: Optional[str] = None
     client_id: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "proxygen-cli"
-version = "2.0.11"
+version = "2.0.12"
 description = "CLI for interacting with NHSD APIM's proxygen service"
 authors = ["Ben Strutt <ben.strutt1@nhs.net>"]
 readme = "README.md"


### PR DESCRIPTION
DO NOT MERGE UNTIL KEYCLOAK HAS BEEN UPGRADED

Path will change when keycloak is upgraded