### PR TITLE
APM-4755: set credentials from scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,19 @@ Type `proxygen` to see a list of available commands.
 
 ### Credentials
 
-All users should have individual credentials.
-`proxygen-cli` needs to know about them.
-
-```
-proxygen credentials set username <USERNAME>
-proxygen credentials set password <PASSWORD>
-```
-
 The CLI has its own client credentials, which need to be input.
 Contact `deathstar` squad or the `platforms-api-producer-support` slack channel to find out what they are.
+
+All users should also have individual credentials. `proxygen-cli` needs to know about them.
+
+Simply execute the following command which will prompt you to enter your `client_id`, `client_secret`, `username`, and `password`:
 ```
-proxgen credentials set client_id <CLIENT_ID>
-proxgen credentials set client_secret <CLIENT_SECRET>
+proxygen credentials set
+```
+
+If you need to update any credentials in the future, use the following command:
+```
+proxygen credentials set <KEY> <VALUE>
 ```
 
 

--- a/proxygen_cli/cli/command_credentials.py
+++ b/proxygen_cli/cli/command_credentials.py
@@ -5,7 +5,7 @@ import pydantic
 
 from proxygen_cli.lib import output
 from proxygen_cli.lib.credentials import (
-    Credentials, get_credentials, _yaml_credentials_file_source, create_yaml_credentials_file)
+    Credentials, get_credentials, _yaml_credentials_file_source, create_yaml_credentials_file, initialise_credentials)
 from proxygen_cli.lib.dot_proxygen import credentials_file
 
 CHOICE_OF_CREDENTIAL_KEYS = click.Choice(Credentials.__fields__.keys())
@@ -21,6 +21,10 @@ def list():
     """
     List all credentials values.
     """
+    if not _yaml_credentials_file_source(None):
+        click.echo("Credentials file does not exist. Please run 'proxygen credentials set'")
+        exit()
+
     creds = get_credentials()
     output.print_spec(json.loads(creds.json(exclude_none=True)))
 
@@ -31,6 +35,10 @@ def get(key):
     """
     Read a value from your credentials.
     """
+    if not _yaml_credentials_file_source(None):
+        click.echo("Credentials file does not exist. Please run 'proxygen credentials set'")
+        exit()
+
     creds = get_credentials()
     click.echo(getattr(creds, key))
 
@@ -77,6 +85,8 @@ def set(custom_pairs, force):
 
     with credentials_file().open("w") as f:
         yaml.safe_dump(new_credentials, f)
+
+    initialise_credentials()
 
 
 @credentials.command()

--- a/proxygen_cli/cli/command_credentials.py
+++ b/proxygen_cli/cli/command_credentials.py
@@ -4,7 +4,8 @@ import yaml
 import click
 
 from proxygen_cli.lib import output
-from proxygen_cli.lib.credentials import Credentials, get_credentials, _yaml_credentials_file_source
+from proxygen_cli.lib.credentials import (
+    Credentials, get_credentials, _yaml_credentials_file_source, create_yaml_credentials_file)
 from proxygen_cli.lib.dot_proxygen import credentials_file
 
 CHOICE_OF_CREDENTIAL_KEYS = click.Choice(Credentials.__fields__.keys())
@@ -23,6 +24,7 @@ def list():
     creds = get_credentials()
     output.print_spec(json.loads(creds.json(exclude_none=True)))
 
+
 @credentials.command()
 @click.argument("key", type=CHOICE_OF_CREDENTIAL_KEYS)
 def get(key):
@@ -40,17 +42,20 @@ def set(key, value):
     """
     Write a value to your credentials.
     """
+    if not _yaml_credentials_file_source(None):
+        create_yaml_credentials_file()
+
     current_credentials = _yaml_credentials_file_source(None)
     current_credentials[key] = value
+
     try:
         new_credentials = json.loads(Credentials(**current_credentials).json(exclude_none=True))
     except pydantic.ValidationError as e:
         errors = json.loads(e.json())
         raise click.BadParameter("\n".join(error["msg"] for error in errors))
+
     with credentials_file().open("w") as f:
         yaml.safe_dump(new_credentials, f)
-
-    
 
 
 @credentials.command()

--- a/proxygen_cli/cli/command_credentials.py
+++ b/proxygen_cli/cli/command_credentials.py
@@ -63,7 +63,7 @@ def set(custom_pairs, force):
 
     if not base_credentials_set or force:
         client_id = click.prompt("Enter client_id")
-        client_secret = click.prompt("Enter client_secret")
+        client_secret = click.prompt("Enter client_secret", default="", show_default=False)
         username = click.prompt("Enter username", default="", show_default=False)
         password = click.prompt("Enter password", default="", show_default=False)
 

--- a/proxygen_cli/lib/credentials.py
+++ b/proxygen_cli/lib/credentials.py
@@ -37,7 +37,7 @@ class Credentials(BaseSettings):
     private_key_path: Optional[str] = None
     key_id: Optional[str] = None
     client_id: str
-    client_secret: str = None
+    client_secret: Optional[str] = None
     username: Optional[str] = None
     password: Optional[str] = None
 

--- a/proxygen_cli/lib/credentials.py
+++ b/proxygen_cli/lib/credentials.py
@@ -113,24 +113,26 @@ class Credentials(BaseSettings):
 
 
 _CREDENTIALS = None
-try:
-    _CREDENTIALS = Credentials()
-except ValidationError as e:  # pragma: no cover
-
-    errors = json.loads(e.json())
-    print("*" * 100, file=sys.stderr)
-    print(
-        "Warning: Credentials invalid or not configured. See `proxygen credentials`.",
-        file=sys.stderr,
-    )
-    details = "  " + "\n  ".join(
-        f"{error['loc'][0]}: {error['msg']}" for error in errors
-    )
-    print(details, file=sys.stderr)
-    print("*" * 100, file=sys.stderr)
-    _CREDENTIALS = None
+def initialise_credentials():
+    global _CREDENTIALS
+    try:
+        _CREDENTIALS = Credentials()
+    except ValidationError as e:
+        errors = json.loads(e.json())
+        print("*" * 100, file=sys.stderr)
+        print(
+            "Warning: Credentials invalid or not configured. See `proxygen credentials`.",
+            file=sys.stderr,
+        )
+        details = "  " + "\n  ".join(
+            f"{error['loc'][0]}: {error['msg']}" for error in errors
+        )
+        print(details, file=sys.stderr)
+        print("*" * 100, file=sys.stderr)
+        _CREDENTIALS = None
 
 
 def get_credentials():
+    initialise_credentials()
     global _CREDENTIALS
     return _CREDENTIALS

--- a/proxygen_cli/lib/credentials.py
+++ b/proxygen_cli/lib/credentials.py
@@ -3,6 +3,7 @@ import json
 from typing import Optional
 import yaml
 import sys
+import os
 
 import click
 from pydantic import (
@@ -21,6 +22,14 @@ def _yaml_credentials_file_source(_):
         return credentials or {}
 
 
+def create_yaml_credentials_file():
+    file_path = os.path.expanduser("~/.proxygen/credentials.yaml")
+
+    if not os.path.exists(file_path):
+        with open(file_path, 'w'):
+            pass
+
+
 class Credentials(BaseSettings):
     base_url: AnyHttpUrl = (
         "https://identity.prod.api.platform.nhs.uk/realms/api-producers"
@@ -29,13 +38,21 @@ class Credentials(BaseSettings):
     key_id: Optional[str] = None
     client_id: str
     client_secret: str = None
-    username: str = None
-    password: str = None
+    username: Optional[str] = None
+    password: Optional[str] = None
+
+    _initialised = False
 
     @validator("username", "password", "client_secret", "client_id")
     def validate_humans_users(cls, value, values):
-        if values.get("private_key_path") is None and value is None:
-            raise ValueError("field required")
+        if not cls._initialised:
+            return value
+
+        private_key_path = values.get("private_key_path")
+        if private_key_path is None and value is None and any(
+            key in values for key in ["username", "password", "client_secret", "client_id"]
+        ):
+            raise ValueError(f"{value} field required")
         return value
 
     def private_key(self):
@@ -47,12 +64,12 @@ class Credentials(BaseSettings):
             )
         with private_key_file.open() as f:
             return f.read()
-        
+
     @validator("key_id")
     def validate_kid(cls, kid, values):
         """
-        If authenticating using a machine (with an associated jwks configured in Keycloak) key, then the key id is required 
-        for newer versions of Keycloak.
+        If authenticating using a machine (with an associated jwks configured in Keycloak) key,
+        then the key id is required for newer versions of Keycloak.
         """
         if values.get("private_key_path") and not kid:
             raise ValueError("Private key specified with no associated Key ID (KID)")
@@ -65,7 +82,7 @@ class Credentials(BaseSettings):
         So take string.
         """
         return cls._validate_private_key_path(private_key_path)
-    
+
     @staticmethod
     def _validate_private_key_path(private_key_path):
         """
@@ -106,7 +123,7 @@ class Credentials(BaseSettings):
 _CREDENTIALS = None
 try:
     _CREDENTIALS = Credentials()
-except ValidationError as e: # pragma: no cover
+except ValidationError as e:  # pragma: no cover
 
     errors = json.loads(e.json())
     print("*" * 100, file=sys.stderr)

--- a/proxygen_cli/lib/credentials.py
+++ b/proxygen_cli/lib/credentials.py
@@ -41,18 +41,10 @@ class Credentials(BaseSettings):
     username: Optional[str] = None
     password: Optional[str] = None
 
-    _initialised = False
-
     @validator("username", "password", "client_secret", "client_id")
     def validate_humans_users(cls, value, values):
-        if not cls._initialised:
-            return value
-
-        private_key_path = values.get("private_key_path")
-        if private_key_path is None and value is None and any(
-            key in values for key in ["username", "password", "client_secret", "client_id"]
-        ):
-            raise ValueError(f"{value} field required")
+        if values.get("private_key_path") is None and value is None:
+            raise ValueError("field required")
         return value
 
     def private_key(self):

--- a/proxygen_cli/test/command_credentials_test.py
+++ b/proxygen_cli/test/command_credentials_test.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import yaml
 import pytest
 from click.testing import CliRunner
 from pydantic.error_wrappers import ValidationError
@@ -72,7 +73,7 @@ def test_private_key_id_missing(patch_config):
     """
     mock_credentials = get_test_credentials()
 
-    with patch_config(credentials=mock_credentials),\
+    with patch_config(credentials=mock_credentials), \
             patch(("proxygen_cli.lib.credentials.Credentials."
                    "_validate_private_key_path")) as mock_creds:
         mock_creds.return_value = True
@@ -107,11 +108,61 @@ def test_set_credential(patch_config, credentials_file):
     assert credentials_file() == expected_credentials
 
 
+def test_update_credentials(patch_config, credentials_file):
+    mock_credentials = get_test_credentials()
+
+    # Convert mock_credentials to a dictionary
+    mock_credentials_dict = yaml.safe_load(mock_credentials)
+
+    # Set an initial value for the username field
+    initial_username = "old-username"
+    mock_credentials_dict["username"] = initial_username
+
+    with patch_config(credentials=mock_credentials):
+        runner = CliRunner()
+        runner.invoke(cmd_credentials.set, ["username", "new-username123"])
+
+    expected_credentials = "\n".join(
+        [
+            "base_url: https://mock-keycloak-url.nhs.uk",
+            "client_id: mock-api-client",
+            "client_secret: 1a2f4g5",
+            "password: mock-password",
+            "username: new-username123",  # Updated value
+        ]
+    )
+
+    # Check the file has been written to
+    assert credentials_file() == expected_credentials
+
+
+def test_add_key_id(patch_config, credentials_file):
+    mock_credentials = get_test_credentials()
+
+    with patch_config(credentials=mock_credentials):
+        runner = CliRunner()
+        runner.invoke(cmd_credentials.set, ["key_id", "test_kid"])
+
+    expected_credentials = "\n".join(
+        [
+            "base_url: https://mock-keycloak-url.nhs.uk",
+            "client_id: mock-api-client",
+            "client_secret: 1a2f4g5",
+            "key_id: test_kid",
+            "password: mock-password",
+            "username: mock-user",
+        ]
+    )
+
+    # Check the file has been written to
+    assert credentials_file() == expected_credentials
+
+
 def test_set_invalid_setting():
     runner = CliRunner()
     result = runner.invoke(cmd_credentials.set, ["invalid", "new-username"])
 
-    assert "'invalid' is not one of 'base_url'" in result.output.strip()
+    assert "Error: Invalid value: extra fields not permitted" in result.output.strip()
 
 
 def test_set_invalid_private_key_path():

--- a/proxygen_cli/test/command_credentials_test.py
+++ b/proxygen_cli/test/command_credentials_test.py
@@ -158,18 +158,22 @@ def test_add_key_id(patch_config, credentials_file):
     assert credentials_file() == expected_credentials
 
 
-def test_set_invalid_setting():
-    runner = CliRunner()
-    result = runner.invoke(cmd_credentials.set, ["invalid", "new-username"])
+def test_set_invalid_setting(patch_config):
+    mock_credentials = get_test_credentials()
+    with patch_config(credentials=mock_credentials):
+        runner = CliRunner()
+        result = runner.invoke(cmd_credentials.set, ["invalid", "new-username"])
 
     assert "Error: Invalid value: extra fields not permitted" in result.output.strip()
 
 
-def test_set_invalid_private_key_path():
-    runner = CliRunner()
-    result = runner.invoke(
-        cmd_credentials.set, ["private_key_path", "invalid_private_key_path"]
-    )
+def test_set_invalid_private_key_path(patch_config):
+    mock_credentials = get_test_credentials()
+    with patch_config(credentials=mock_credentials):
+        runner = CliRunner()
+        result = runner.invoke(
+            cmd_credentials.set, ["private_key_path", "invalid_private_key_path"]
+        )
 
     assert ".proxygen/invalid_private_key_path does not exist" in result.output.strip()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "proxygen-cli"
-version = "2.0.15"
+version = "2.0.16"
 description = "CLI for interacting with NHSD APIM's proxygen service"
 authors = ["Ben Strutt <ben.strutt1@nhs.net>"]
 readme = "README.md"


### PR DESCRIPTION
Summary of changes:
- I have modelled the 'set' command against the aws-cli format. Now when the user executes `proxygen credentials set` they are promted to input `client_id`, `client_secret`, `username`, `password` as default values. 
- `username` and `password` can be left empty
- User can still do `proyxgen credentials set username fayez.ahmed1` if they wish. This will overwrite the existing saved `username` value
- `--force` flag added so that the user can reset their credentials if they wish
- A `credentials.yaml` file is created from scratch if it does not already exist in a users root directory
- Added tests
- General formatting improvements
- Updated documentation