### PR TITLE
APM-4830: CLI falsely reports success

### DIFF
--- a/proxygen_cli/cli/command_instance.py
+++ b/proxygen_cli/cli/command_instance.py
@@ -80,6 +80,7 @@ def deploy(ctx, env, base_path, spec_file, no_confirm):
         try:
             result = proxygen_api.put_instance(api, env, instance, paas_open_api)
             if result is None:
+                sp.fail("✘")
                 raise click.ClickException(f"No such instance {_url}")
 
             sp.ok("✔")
@@ -134,9 +135,11 @@ def delete(ctx, env, base_path, no_confirm):
         try:
             result = proxygen_api.delete_instance(api, env, instance)
             if result is None:
+                sp.fail("✘")
                 raise click.ClickException(f"No such instance {_url}")
 
             sp.ok("✔")
+
         except Exception as e:
             sp.fail("✘")
             click.echo(f"Failed to deploy instance {_url}. Error: {str(e)}")

--- a/proxygen_cli/cli/command_instance.py
+++ b/proxygen_cli/cli/command_instance.py
@@ -80,7 +80,7 @@ def deploy(ctx, env, base_path, spec_file, no_confirm):
         try:
             result = proxygen_api.put_instance(api, env, instance, paas_open_api)
             if result is None:
-                raise click.ClickException(f"No such instance {_url}")
+                raise click.ClickException(f"Invalid instance {_url}")
 
             sp.ok("✔")
 

--- a/proxygen_cli/cli/command_instance.py
+++ b/proxygen_cli/cli/command_instance.py
@@ -70,14 +70,25 @@ def deploy(ctx, env, base_path, spec_file, no_confirm):
 
     if not no_confirm:
         output.print_spec(paas_open_api)
-        if not click.confirm(f"Deploy this spec to {_url}?"): # pragma: no cover
+        if not click.confirm(f"Deploy this spec to {_url}?"):  # pragma: no cover
             raise click.Abort()
 
     with yaspin() as sp:
         sp.text = f"Deploying {_url}"
         instance = parse.quote(base_path)
-        result = proxygen_api.put_instance(api, env, instance, paas_open_api)
-        sp.ok("✔")
+
+        try:
+            result = proxygen_api.put_instance(api, env, instance, paas_open_api)
+            if result is None:
+                raise click.ClickException(f"No such instance {_url}")
+
+            sp.ok("✔")
+
+        except Exception as e:
+            sp.fail("✘")
+            click.echo(f"Failed to deploy instance {_url}. Error: {str(e)}")
+
+
 @instance.command()
 @click.argument("env", type=CHOICE_OF_ENVS)
 @click.argument("base_path")
@@ -106,6 +117,7 @@ def delete(ctx, env, base_path, no_confirm):
     api = ctx.obj["api"]
     instance = parse.quote(base_path)
     _url = spec.url(env, base_path)
+
     if not no_confirm:
         result = proxygen_api.get_instance(api, env, instance)
         if not result:
@@ -116,7 +128,15 @@ def delete(ctx, env, base_path, no_confirm):
 
     with yaspin() as sp:
         sp.text = f"Deleting {_url}"
-        api = ctx.obj["api"]
-        instance = parse.quote(base_path)
-        result = proxygen_api.delete_instance(api, env, instance)
-        sp.ok("✔")
+        # api = ctx.obj["api"]
+        # instance = parse.quote(base_path)
+
+        try:
+            result = proxygen_api.delete_instance(api, env, instance)
+            if result is None:
+                raise click.ClickException(f"No such instance {_url}")
+
+            sp.ok("✔")
+        except Exception as e:
+            sp.fail("✘")
+            click.echo(f"Failed to deploy instance {_url}. Error: {str(e)}")

--- a/proxygen_cli/cli/command_instance.py
+++ b/proxygen_cli/cli/command_instance.py
@@ -80,7 +80,6 @@ def deploy(ctx, env, base_path, spec_file, no_confirm):
         try:
             result = proxygen_api.put_instance(api, env, instance, paas_open_api)
             if result is None:
-                sp.fail("✘")
                 raise click.ClickException(f"No such instance {_url}")
 
             sp.ok("✔")
@@ -129,13 +128,10 @@ def delete(ctx, env, base_path, no_confirm):
 
     with yaspin() as sp:
         sp.text = f"Deleting {_url}"
-        # api = ctx.obj["api"]
-        # instance = parse.quote(base_path)
 
         try:
             result = proxygen_api.delete_instance(api, env, instance)
             if result is None:
-                sp.fail("✘")
                 raise click.ClickException(f"No such instance {_url}")
 
             sp.ok("✔")

--- a/proxygen_cli/lib/auth.py
+++ b/proxygen_cli/lib/auth.py
@@ -105,7 +105,7 @@ def _get_token_data_from_user_login():
     )
 
     if login_page_resp.status_code != 200:
-        raise RunTimeError(f"Login page get request status was {login_page_resp.status_code} expected to be 200")
+        raise RuntimeError(f"Login page get request status was {login_page_resp.status_code} expected to be 200")
 
     login_form = html.fromstring(login_page_resp.content.decode()).get_element_by_id(
         "kc-form-login"

--- a/proxygen_cli/test/command_instance_test.py
+++ b/proxygen_cli/test/command_instance_test.py
@@ -191,6 +191,27 @@ def test_instance_deploy_with_confirm(patch_pathlib, patch_access_token, patch_r
     assert "Aborted!" in result.output.strip()
 
 
+def test_instance_deploy_invalid_instance_name(patch_pathlib, patch_access_token, patch_request):
+    env = "internal-dev"
+
+    runner = CliRunner()
+    with patch(
+        "proxygen_cli.lib.proxygen_api.access_token"
+    ) as _access_token, patch_request(404, {}), patch_pathlib(
+        "test-yaml-key: test-yaml-value"
+    ):
+        _access_token.return_value = "12345"
+        result = runner.invoke(
+            cmd_instance.deploy,
+            [env, "mock-api-base-path", "specification/mock-api-spec", "--no-confirm"],
+            obj={"api": "mock-api"},
+        )
+
+    assert (
+        "No such instance https://internal-dev.api.service.nhs.uk/mock-api-base-path"
+        in result.output.strip())
+
+
 def test_instance_get(patch_request, patch_pathlib, patch_access_token):
     env = "internal-dev"
 
@@ -207,9 +228,71 @@ def test_instance_get(patch_request, patch_pathlib, patch_access_token):
     assert "mocked-spec-yaml: mocked-spec-goes-here" in result.output.strip()
 
 
-def test_instance_delete_with_confirm():
-    pass
+def test_instance_delete_no_confirm(patch_request, patch_pathlib, patch_access_token):
+    env = "internal-dev"
+    base_path = "mock-api-base-path"
+    instance_name = "gp-registrations-mi"
+
+    # Mock the instance to be deleted
+    mock_instance = {
+        "environment": env,
+        "type": "instance",
+        "name": instance_name,
+        "last_modified": "2023-02-27T15:46:10+00:00",
+        "spec_hash": "31e4f4f2c85f133dd0ffb194c14c8bae",
+    }
+
+    runner = CliRunner()
+    with patch_access_token(), patch_request(200, mock_instance), patch_pathlib(
+        "test-yaml-key: test-yaml-value"
+    ):
+        result = runner.invoke(
+            cmd_instance.delete,
+            [env, base_path, "--no-confirm"],
+            obj={"api": "mock-api"},
+        )
+
+    assert "✔ Deleting https://internal-dev.api.service.nhs.uk/mock-api-base-path" in result.output.strip()
 
 
-def test_instance_delete_no_confirm():
-    pass
+def test_instance_delete_with_confirm(patch_request, patch_pathlib, patch_access_token):
+    env = "internal-dev"
+    base_path = "mock-api-base-path"
+    instance_name = "gp-registrations-mi"
+
+    # Mock the instance to be deleted
+    mock_instance = {
+        "environment": env,
+        "type": "instance",
+        "name": instance_name,
+        "last_modified": "2023-02-27T15:46:10+00:00",
+        "spec_hash": "31e4f4f2c85f133dd0ffb194c14c8bae",
+    }
+
+    runner = CliRunner()
+    with patch_access_token(), patch_request(200, mock_instance), patch_pathlib(
+        "test-yaml-key: test-yaml-value"
+    ), patch("click.confirm", return_value=True):
+        result = runner.invoke(
+            cmd_instance.delete,
+            [env, base_path],
+            obj={"api": "mock-api"},
+        )
+
+    assert "✔ Deleting https://internal-dev.api.service.nhs.uk/mock-api-base-path" in result.output.strip()
+
+
+def test_instance_delete_invalid_instance_name(patch_request, patch_pathlib, patch_access_token):
+    env = "internal-dev"
+
+    runner = CliRunner()
+    with patch_access_token(), patch_request(404, {}), patch_pathlib(
+        "test-yaml-key: test-yaml-value"
+    ):
+        result = runner.invoke(
+            cmd_instance.delete,
+            [env, "mock-api-base-path", "--no-confirm"],
+            obj={"api": "mock-api"},
+        )
+
+    assert "No such instance https://internal-dev.api.service.nhs.uk/mock-api-base-path" in result.output.strip()

--- a/proxygen_cli/test/command_instance_test.py
+++ b/proxygen_cli/test/command_instance_test.py
@@ -208,7 +208,7 @@ def test_instance_deploy_invalid_instance_name(patch_pathlib, patch_access_token
         )
 
     assert (
-        "No such instance https://internal-dev.api.service.nhs.uk/mock-api-base-path"
+        "Invalid instance https://internal-dev.api.service.nhs.uk/mock-api-base-path"
         in result.output.strip())
 
 

--- a/proxygen_cli/test/command_instance_test.py
+++ b/proxygen_cli/test/command_instance_test.py
@@ -205,3 +205,11 @@ def test_instance_get(patch_request, patch_pathlib, patch_access_token):
         )
 
     assert "mocked-spec-yaml: mocked-spec-goes-here" in result.output.strip()
+
+
+def test_instance_delete_with_confirm():
+    pass
+
+
+def test_instance_delete_no_confirm():
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "proxygen-cli"
-version = "2.0.17"
+version = "2.0.18"
 description = "CLI for interacting with NHSD APIM's proxygen service"
 authors = ["Ben Strutt <ben.strutt1@nhs.net>"]
 readme = "README.md"


### PR DESCRIPTION
Summary of changes:

- Added validation to `deploy` and `delete` commands so that if proxygen returns a 404 the cli will display the message "No such instance {url}"
- Added tests
- Formatting changes

**NOTE:** Due to the way the CLI was originally coded, if proxygen returns a 404 and is passed through to the JSON data it reutrns None. If proxygen returns 200 then an empty object can be passed through. This is why I have done `if result is None`, rather than `if not result` as it may always get triggered. 